### PR TITLE
Checking method availability before calling Log::flushSharedContext()

### DIFF
--- a/QueueServiceProvider.php
+++ b/QueueServiceProvider.php
@@ -197,8 +197,10 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 return $this->app->isDownForMaintenance();
             };
 
-            $resetScope = function () use ($app) {
-                $app['log']->flushSharedContext();
+            $resetScope = function () use ($app) {                
+                if (method_exists($app['log'], 'flushSharedContext')) {
+                    $app['log']->flushSharedContext();
+                }
 
                 if (method_exists($app['log'], 'withoutContext')) {
                     $app['log']->withoutContext();


### PR DESCRIPTION
There are some edge cases where `$app['log']` may not contain `flushSharedContext()` method.  
In the next statement, in the case of `withoutContext()`, it's checking for method existence. Similarly, I think i'd be nice to check method existence before calling this function too.

### Background
I was trying to use `Queue` in a Laravel Zero app without installing `log` component. And was getting this error:
```
Call to undefined method Psr\Log\NullLogger::flushSharedContext()
at vendor/illuminate/queue/QueueServiceProvider.php:201
```
![CleanShot 2024-08-13 at 19 39 52@2x](https://github.com/user-attachments/assets/428cf3c8-a6fb-4fbf-93fc-46713667b2d7)

Then I checked and found that, the `Psr\Log\NullLogger` actually don't have this method.